### PR TITLE
Fix FutureWarning in pretrained.py by setting weights_only=True in torch.load

### DIFF
--- a/vocos/pretrained.py
+++ b/vocos/pretrained.py
@@ -67,7 +67,7 @@ class Vocos(nn.Module):
         config_path = hf_hub_download(repo_id=repo_id, filename="config.yaml", revision=revision)
         model_path = hf_hub_download(repo_id=repo_id, filename="pytorch_model.bin", revision=revision)
         model = cls.from_hparams(config_path)
-        state_dict = torch.load(model_path, map_location="cpu")
+        state_dict = torch.load(model_path, map_location="cpu", weights_only=True)
         if isinstance(model.feature_extractor, EncodecFeatures):
             encodec_parameters = {
                 "feature_extractor.encodec." + key: value


### PR DESCRIPTION
**Description:**  
This PR updates the `torch.load` call in `vocos\pretrained.py` to set `weights_only=True`, following PyTorch's guidance for mitigating potential security risks with `pickle` deserialization in untrusted environments. (as noted in https://github.com/gemelo-ai/vocos/issues/61)

- **Tested on** PyTorch v2.4.1 with no warning output






